### PR TITLE
fix: [#6] switch output from libpcap to wiretap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 pcapdj:		pcapdj.o
-	gcc -Wall -o pcapdj pcapdj.o -lwiretap `pkg-config --libs glib-2.0` -lpcap -lhiredis -ggdb
+	gcc -Wall -o pcapdj pcapdj.o -lwiretap -lwsutil `pkg-config --libs glib-2.0` -lhiredis -ggdb
 pcapdj.o:	pcapdj.c
 	gcc -Wall -c pcapdj.c `pkg-config --cflags glib-2.0` -I /usr/include/wireshark/wiretap -I /usr/include/wireshark/wsutil -I /usr/include/wireshark `pkg-config --libs glib-2.0` -I /usr/local/include/hiredis -ggdb
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Dependencies
 
 In an Ubuntu 16.04 Operating system the following packages must be installed.
 
-apt-get install libwsutil-dev libwiretap-dev libpcap-dev libhiredis-dev libglib2.0-dev
+apt-get install libwsutil-dev libwiretap-dev libhiredis-dev libglib2.0-dev
 
 Compiling
 ---------


### PR DESCRIPTION
I open this PR mainly to discuss its limitations:

- no time conversion micro / nano (I did not check whether it's still needed-is it?)
- need to specify the encapsulation type before accessing the fifo for write ops, ATM I set it `WTAP_ENCAP_ETHERNET`-it is a regression?. This could become a flag.

Expect a few more changes on this branch,~~it should be easy straightforward to support compressed files for instance.~~-> it's already supported.